### PR TITLE
fix: re-export SDK defaults as live bindings so cycles can't null them

### DIFF
--- a/src/lib/api.util.js
+++ b/src/lib/api.util.js
@@ -1,5 +1,9 @@
-import { default as Default } from '@panomc/sdk/core/js/api.util';
-
+// `export { default } from` (not `import` + `export default Default`) because this
+// shim sits inside an import cycle: the engine's hooks-server → lib/services/auth.js
+// → $pano/lib/api.util → @panomc/sdk/core/js/api.util → $lib/Store.js → back here.
+// `export default <identifier>` is an expression evaluated once while the SDK module
+// is still in-flight, so it would snapshot an uninitialized binding and publish
+// `undefined` forever. A re-export is an indirect binding resolved at link time and
+// read on access, so it survives the cycle.
 export * from '@panomc/sdk/core/js/api.util';
-
-export default Default;
+export { default } from '@panomc/sdk/core/js/api.util';

--- a/src/lib/csrf.js
+++ b/src/lib/csrf.js
@@ -1,5 +1,5 @@
-import { default as Default } from '@panomc/sdk/core/js/csrf.js';
-
+// Re-export rather than `import` + `export default Default` — see api.util.js: the
+// snapshot form publishes `undefined` if the SDK module is still in-flight because of
+// an import cycle.
 export * from '@panomc/sdk/core/js/csrf.js';
-
-export default Default;
+export { default } from '@panomc/sdk/core/js/csrf.js';

--- a/src/lib/tooltip.util.js
+++ b/src/lib/tooltip.util.js
@@ -1,5 +1,5 @@
-import { default as Default } from '@panomc/sdk/core/js/tooltip.util';
-
+// Re-export rather than `import` + `export default Default` — see api.util.js: the
+// snapshot form publishes `undefined` if the SDK module is still in-flight because of
+// an import cycle.
 export * from '@panomc/sdk/core/js/tooltip.util';
-
-export default Default;
+export { default } from '@panomc/sdk/core/js/tooltip.util';


### PR DESCRIPTION
## Problem

Every panel request 500s:

```
TypeError: Cannot read properties of undefined (reading 'get')
    at fetchBasicData (src/hooks.server.js:9:18)
    at resolveLocals (src/hooks.server.js:37:30)
    at Object.handle (node_modules/@panomc/theme-core/src/kit/hooks-server.js:246:13)
```

`ApiUtil` imported from `$lib/api.util.js` is `undefined`.

## Cause

The panel's `$lib/{api.util,tooltip.util,csrf}.js` shims re-publish the SDK default with:

```js
import { default as Default } from '@panomc/sdk/core/js/api.util';
export * from '@panomc/sdk/core/js/api.util';
export default Default;
```

`export default Default;` is an **expression**, evaluated once while the shim's body runs — not a live binding. It snapshots whatever `Default` holds at that instant.

theme-core's `kit/hooks-server.js` now imports `lib/services/auth.js`, which imports `$pano/lib/api.util`. The engine graph therefore reaches `@panomc/sdk/core/js/api.util` **before** the panel's own shim, and the SDK module statically imports `$lib/Store.js`, which imports `$lib/api.util`:

```
src/hooks.server.js
 └→ $pano/kit/hooks-server.js
     └→ theme-core/src/lib/services/auth.js
         └→ theme-core/src/lib/api.util.js
             └→ @panomc/sdk/core/js/api.util      ← starts evaluating
                 └→ $lib/Store.js                 (sdk api.util:5)
                     └→ $lib/api.util.js
                         └→ @panomc/sdk/core/js/api.util  ← in-flight, default unset
                         └→ export default Default        ← snapshots undefined, permanently
```

`hooks.server.js:5` then imports that module and gets `undefined`.

(Rolldown flags the same edge during build: `src/lib/Store.js ... also statically imported by node_modules/@panomc/sdk/core/js/api.util.js`.)

## Fix

```js
export * from '@panomc/sdk/core/js/api.util';
export { default } from '@panomc/sdk/core/js/api.util';
```

`export { default } from` is an indirect binding resolved at link time and read on access, so the cycle can't null it.

This is the form theme-core's own `sync` CLI already generates for themes — see `themes/vanilla-theme/src/lib/api.util.js`. The panel's hand-written shims were the last holdouts of the older snapshot form, which is why only panel-ui broke: thin themes have no duplicate shim layer.

Applied to all three shims, not just `api.util`, because they share the pattern and the evaluation order that currently saves `tooltip.util`/`csrf` is incidental.

## Verification

- Reproduced the exact stack on an isolated dev server (port 3099, untouched from the dev port 3001) against the unpatched tree.
- After the change the `reading 'get'` error is gone across fresh requests; anonymous curl now fails further downstream in `Dashboard.svelte:84` on `gettingStartedBlocks.welcomeBoard` — the API returns 401 without a session cookie, which proves `ApiUtil.get` executed and returned.
- `vite build` (production, `DEV=false`) exits 0.
- `prettier -c` clean on all three files.

## Follow-up (not in this PR)

`theme-core/packages/theme-core/src/lib/{api.util,tooltip.util,csrf}.js` carry the identical snapshot form. They happen to evaluate in a safe order today, but it is the same latent bug in the engine shipped to every theme. `setup-ui/src/lib/{api.util,tooltip.util}.js` too.